### PR TITLE
Simplifies CMakeLists.txt and package.xml after removing Gazebo plugin

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,21 +4,17 @@
   <version>2.0.0</version>
   <description>The talos_data package</description>
 
-  <maintainer email="olivier.stasse@laas.fr">Olivier Stasse</maintainer>
+  <maintainer email="guilhem.saurel@laas.fr">Guilhem Saurel</maintainer>
 
   <license>LGPL-3.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-
   <exec_depend>talos_description_calibration</exec_depend>
   <exec_depend>talos_description_inertial</exec_depend>
-  <exec_depend>roscpp</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>urdf_test</test_depend>
-  <test_depend>roscpp</test_depend>
 
   <export>
   </export>


### PR DESCRIPTION
Remove dependencies on roscpp, export Target, remove library.